### PR TITLE
Changed logic so order of the latitude and longitude in gpx file does not matter anymore

### DIFF
--- a/strava_local_heatmap.py
+++ b/strava_local_heatmap.py
@@ -22,6 +22,7 @@
 import os
 import glob
 import time
+import re
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -127,10 +128,10 @@ def main(args: Namespace) -> None:
                     if not args.year or l in args.year:
                         for line in file:
                             if '<trkpt' in line:
-                                l = line.split('"')
-
-                                lat_lon_data.append([float(l[1]),
-                                                     float(l[3])])
+                                lon = re.findall(r"lon=\"(-?[0-9]+.?[0-9]*)\"", line)[0]
+                                lat = re.findall(r"lat=\"(-?[0-9]+.?[0-9]*)\"", line)[0]
+                                lat_lon_data.append([float(lat),
+                                                     float(lon)])
 
                     else:
                         break


### PR DESCRIPTION
* Original implementation read all the lines in GPX file and assumed latitude was placed before longitude in the file. This is not the case for GPX files from e.g. Apple Watch. Logic was changed to retrieve the value based on the key (lon/lat) in front of the value (thus making it more compatible with different GPX files)